### PR TITLE
fix: an error occurs: when dirname contained "src"

### DIFF
--- a/engine/utils.go
+++ b/engine/utils.go
@@ -81,9 +81,9 @@ func PackageAbsPath(path string) (packagePath string) {
 		glog.Fatal(err)
 	}
 
-	packagePathIndex := strings.LastIndex(absPath, "src")
+	packagePathIndex := strings.LastIndex(absPath, "/src/")
 	if -1 != packagePathIndex {
-		packagePath = absPath[(packagePathIndex + 4):]
+		packagePath = absPath[(packagePathIndex + 5):]
 	}
 
 	return packagePath


### PR DESCRIPTION
Panic occurred when dirname contained "src".
Fixed.

example: `path := "/gohome/src/github.com/codegangsta/cli/altsrc"`
https://play.golang.org/p/REko9nEiwd